### PR TITLE
Corrige relacionamento de endereços no exportador

### DIFF
--- a/app/Models/Exporter/Builders/EnrollmentEloquentBuilder.php
+++ b/app/Models/Exporter/Builders/EnrollmentEloquentBuilder.php
@@ -229,7 +229,7 @@ class EnrollmentEloquentBuilder extends Builder
         if ($only = $this->model->getLegacyExportedColumns('place', $columns)) {
             $this->addSelect($only);
 
-            $this->leftJoin('places as p', 'p.id', 'person_has_place.id')
+            $this->leftJoin('places as p', 'p.id', 'person_has_place.place_id')
                 ->leftJoin('cities as c', 'c.id', 'p.city_id')
                 ->leftJoin('states as s', 's.id', 'c.state_id')
                 ->leftJoin('countries as cn', 'cn.id', 's.country_id');

--- a/app/Models/Exporter/Builders/StudentEloquentBuilder.php
+++ b/app/Models/Exporter/Builders/StudentEloquentBuilder.php
@@ -203,7 +203,7 @@ class StudentEloquentBuilder extends Builder
         if ($only = $this->model->getLegacyExportedColumns('place', $columns)) {
             $this->addSelect($only);
 
-            $this->leftJoin('places as p', 'p.id', 'person_has_place.id')
+            $this->leftJoin('places as p', 'p.id', 'person_has_place.place_id')
                 ->leftJoin('cities as c', 'c.id', 'p.city_id')
                 ->leftJoin('states as s', 's.id', 'c.state_id')
                 ->leftJoin('countries as cn', 'cn.id', 's.country_id');


### PR DESCRIPTION
**Contexto**
Os relacionamentos com endereços estavam incorretos e por isso vários alunos constavam com endereço errado no arquivo de exportado. Foi corrigido a exportação de Matrículas e Alunos.