### PR TITLE
Corrige botão de distribuição de uniforme

### DIFF
--- a/ieducar/intranet/educar_aluno_det.php
+++ b/ieducar/intranet/educar_aluno_det.php
@@ -588,7 +588,7 @@ return new class extends clsDetalhe {
             $this->array_botao_url_script = [
                 sprintf('go("educar_matricula_cad.php?ref_cod_aluno=%d");', $registro['cod_aluno']),
                 sprintf('go("educar_historico_escolar_lst.php?ref_cod_aluno=%d");', $registro['cod_aluno']),
-                sprintf('go("educar_distribuicao$this->array_botao_uniforme_lst.php?ref_cod_aluno=%d");', $registro['cod_aluno']),
+                sprintf('go("educar_distribuicao_uniforme_lst.php?ref_cod_aluno=%d");', $registro['cod_aluno']),
                 sprintf('go("sed/aluno/create/%d");', $registro['cod_aluno']),
             ];
 


### PR DESCRIPTION
**Descrição**

Corrige link do botão "Distribuição de uniforme" que estava gerando erro 404:

![image](https://github.com/loginx-tech/i-educar/assets/5911217/5f7986c0-d89d-488d-8c07-23cfbe0348b1)
