### PR TITLE
Fix bugs

### DIFF
--- a/app/Models/Builders/LegacyStudentBuilder.php
+++ b/app/Models/Builders/LegacyStudentBuilder.php
@@ -149,7 +149,7 @@ class LegacyStudentBuilder extends LegacyBuilder
         return $this->with(
             [
                 'individual' => function (BelongsTo $query) {
-                    $query->select(['idpes', 'idpes_mae', 'idpes_pai', 'nome_social']);
+                    $query->select(['idpes', 'idpes_mae', 'idpes_pai', 'idpes_responsavel', 'nome_social']);
                     $query
                         ->with('father:nome,idpes', 'father.individual:cpf,idpes')
                         ->with('mother:nome,idpes', 'mother.individual:cpf,idpes')

--- a/app/Models/UniformDistribution.php
+++ b/app/Models/UniformDistribution.php
@@ -66,8 +66,12 @@ class UniformDistribution extends Model
 
     protected function distributionDate(): Attribute
     {
-        return Attribute::make(
-            set: fn ($value) => Carbon::createFromFormat('d/m/Y', $value),
-        );
+        return Attribute::make(set: function ($value) {
+            if (empty($value)) {
+                return null;
+            }
+
+            return Carbon::createFromFormat('d/m/Y', $value);
+        });
     }
 }

--- a/ieducar/intranet/educar_distribuicao_uniforme_cad.php
+++ b/ieducar/intranet/educar_distribuicao_uniforme_cad.php
@@ -50,20 +50,12 @@ return new class extends clsCadastro {
     {
         $this->uniformDistribution ?? $this->uniformDistribution = new UniformDistribution();
 
-        $objEscola = new clsPmieducarEscola();
-        $lista = $objEscola->lista();
-
-        $escolaOpcoes = ['' => 'Selecione'];
-
-        foreach ($lista as $escola) {
-            $escolaOpcoes["{$escola['cod_escola']}"] = "{$escola['nome']}";
-        }
-
         $this->campoOculto('id', $this->uniformDistribution->id);
 
         $this->campoNumero('year', 'Ano', request('year', $this->uniformDistribution->year), 4, 4, true);
 
-        $this->inputsHelper()->dynamic(['instituicao', 'escola']);
+        $this->inputsHelper()->dynamic('instituicao');
+        $this->inputsHelper()->dynamic('escola', ['value' => $this->uniformDistribution->school_id]);
 
         $this->campoQuebra();
 


### PR DESCRIPTION
### Descrição
- Corrige listagem de alunos que não apresentava nome do responsável quando tipo de responsável igual a "**_Outra pessoa_**";
- Corrige erro ao cadastrar distribuição de uniforme quando o tipo é igual a _**Solicitado**_;
- Corrige edição da tela de distribuição de uniforme que não apresentava a escola informada preenchida;